### PR TITLE
Fixed Issue Adversary Dice

### DIFF
--- a/src/torRpgBot/EmoteInterface.java
+++ b/src/torRpgBot/EmoteInterface.java
@@ -3,8 +3,7 @@ package torRpgBot;
 import net.dv8tion.jda.core.entities.Guild;
 
 public interface EmoteInterface {
-
-	public void getEmoteStrings(Guild guild);
-	public String getSuccessString(int success, boolean isWeary);
-	public String getFeatString(int feat, boolean isAdversary);
+	public void reloadEmotes(Guild guild);
+	public String getSuccessString(int success, boolean isWeary, boolean isAdversary, Guild guild);
+	public String getFeatString(int feat, boolean isAdversary, Guild guild);
 }

--- a/src/torRpgBot/EmoteStrings.java
+++ b/src/torRpgBot/EmoteStrings.java
@@ -1,5 +1,6 @@
 package torRpgBot;
 
+import java.util.Hashtable;
 import java.util.List;
 
 import org.apache.logging.log4j.LogManager;
@@ -11,27 +12,7 @@ import net.dv8tion.jda.core.entities.Guild;
 public class EmoteStrings implements EmoteInterface{
 	
 	private final Logger LOGGER = LogManager.getLogger(EmoteStrings.class.getName());
-	public String d121 = "1";
-	public String d122 = "2";
-	public String d123 = "3";
-	public String d124 = "4";
-	public String d125 = "5";
-	public String d126 = "6";
-	public String d127 = "7";
-	public String d128 = "8";
-	public String d129 = "9";
-	public String d1210 = "10";
-	public String d1211 = "11";
-	public String d1212 = "12";
-	public String d61 = "1";
-	public String d62 = "2";
-	public String d63 = "3";
-	public String d64 = "4";
-	public String d65 = "5";
-	public String d66 = "6";
-	public String d61weary = "1";
-	public String d62weary = "2";
-	public String d63weary = "3";
+	static private Hashtable<String, Hashtable<String, String>> servers = new Hashtable<String, Hashtable<String, String>>();
 		
 		
 	/**
@@ -42,129 +23,103 @@ public class EmoteStrings implements EmoteInterface{
 	 * @param guild The server that the message will be sent to, and so the one needed to retrieve the emoji id from.
 	 * @return void
 	 */
-	public void getEmoteStrings(Guild guild) {
+	private void getEmoteStrings(Guild guild, boolean forceReload) {
+		if (servers.containsKey(guild.getId()) && !forceReload)
+		{
+			return;
+		}
+		
+		LOGGER.debug("Getting emote strings for server {}", guild.getName());
+		Hashtable<String, String> emoteTable = new Hashtable<String, String>();
+		
 		List<Emote> emotes = guild.getEmotes();
 		
 		LOGGER.debug("Getting emotes from guild {}.", guild.getName());
 	
 		for (Emote e : emotes)
 		{
-			switch (e.getName())
+			if (e.getName().matches("^(a){0,1}d((12)|(6))[1-9]([012]{0,1}(weary){0,1})"))
 			{
-			case "d121":
-				this.d121 = "<:d121:" + e.getId()+ ">";
-				break;
-			case "d122":
-				this.d122 = "<:d122:" + e.getId()+ ">";
-				break;
-			case "d123":
-				this.d123 = "<:d123:" + e.getId()+ ">";
-				break;
-			case "d124":
-				this.d124 = "<:d124:" + e.getId()+ ">";
-				break;
-			case "d125":
-				this.d125 = "<:d125:" + e.getId()+ ">";
-				break;
-			case "d126":
-				this.d126 = "<:d126:" + e.getId()+ ">";
-				break;
-			case "d127":
-				this.d127 = "<:d127:" + e.getId()+ ">";
-				break;
-			case "d128":
-				this.d128 = "<:d128:" + e.getId()+ ">";
-				break;
-			case "d129":
-				this.d129 = "<:d129:" + e.getId()+ ">";
-				break;
-			case "d1210":
-				this.d1210 = "<:d1210:" + e.getId()+ ">";
-				break;
-			case "d1211":
-				this.d1211 = "<:d1211:" + e.getId()+ ">";
-				break;
-			case "d1212":
-				this.d1212 = "<:d1212:" + e.getId()+ ">";
-				break;
-			case "d61":
-				this.d61 = "<:d61:" + e.getId()+ ">";
-				break;
-			case "d62":
-				this.d62 = "<:d62:" + e.getId()+ ">";
-				break;
-			case "d63":
-				this.d63 = "<:d63:" + e.getId()+ ">";
-				break;
-			case "d64":
-				this.d64 = "<:d64:" + e.getId()+ ">";
-				break;
-			case "d65":
-				this.d65 = "<:d65:" + e.getId()+ ">";
-				break;
-			case "d66":
-				this.d66 = "<:d66:" + e.getId()+ ">";
-				break;
-			case "d61weary":
-				this.d61weary = "<:d61weary:" + e.getId()+ ">";
-				break;
-			case "d62weary":
-				this.d62weary = "<:d62weary:" + e.getId()+ ">";
-				break;
-			case "d63weary":
-				this.d63weary = "<:d63weary:" + e.getId()+ ">";
-				break;
-			default:
-				break;
+				LOGGER.debug("Inserting emote string {} for emote {}.", ("<:" + e.getName() + ":" + e.getId() + ">"), e.getName());
+				emoteTable.putIfAbsent(e.getName(), "<:" + e.getName() + ":" + e.getId() + ">");
 			}
 		}
+		
+		emoteTable.putIfAbsent("d121", "1");
+		emoteTable.putIfAbsent("d122", "2");
+		emoteTable.putIfAbsent("d123", "3");
+		emoteTable.putIfAbsent("d124", "4");
+		emoteTable.putIfAbsent("d125", "5");
+		emoteTable.putIfAbsent("d126", "6");
+		emoteTable.putIfAbsent("d127", "7");
+		emoteTable.putIfAbsent("d128", "8");
+		emoteTable.putIfAbsent("d129", "9");
+		emoteTable.putIfAbsent("d1210", "10");
+		emoteTable.putIfAbsent("d1211", "11");
+		emoteTable.putIfAbsent("d1212", "12");
+		emoteTable.putIfAbsent("d61", "1");
+		emoteTable.putIfAbsent("d62", "2");
+		emoteTable.putIfAbsent("d63", "3");
+		emoteTable.putIfAbsent("d64", "4");
+		emoteTable.putIfAbsent("d65", "5");
+		emoteTable.putIfAbsent("d66", "6");
+		emoteTable.putIfAbsent("d61weary", "1");
+		emoteTable.putIfAbsent("d62weary", "2");
+		emoteTable.putIfAbsent("d63weary", "3");
+		
+		emoteTable.putIfAbsent("ad121", emoteTable.get("d121"));
+		emoteTable.putIfAbsent("ad122", emoteTable.get("d122"));
+		emoteTable.putIfAbsent("ad123", emoteTable.get("d123"));
+		emoteTable.putIfAbsent("ad124", emoteTable.get("d124"));
+		emoteTable.putIfAbsent("ad125", emoteTable.get("d125"));
+		emoteTable.putIfAbsent("ad126", emoteTable.get("d126"));
+		emoteTable.putIfAbsent("ad127", emoteTable.get("d127"));
+		emoteTable.putIfAbsent("ad128", emoteTable.get("d128"));
+		emoteTable.putIfAbsent("ad129", emoteTable.get("d129"));
+		emoteTable.putIfAbsent("ad1210", emoteTable.get("d1210"));
+		emoteTable.putIfAbsent("ad1211", emoteTable.get("d1211"));
+		emoteTable.putIfAbsent("ad1212", emoteTable.get("d1212"));
+		emoteTable.putIfAbsent("ad61", emoteTable.get("d61"));
+		emoteTable.putIfAbsent("ad62", emoteTable.get("d62"));
+		emoteTable.putIfAbsent("ad63", emoteTable.get("d63"));
+		emoteTable.putIfAbsent("ad64", emoteTable.get("d64"));
+		emoteTable.putIfAbsent("ad65", emoteTable.get("d65"));
+		emoteTable.putIfAbsent("ad66", emoteTable.get("d66"));
+		emoteTable.putIfAbsent("ad61weary", emoteTable.get("d61weary"));
+		emoteTable.putIfAbsent("ad62weary", emoteTable.get("d62weary"));
+		emoteTable.putIfAbsent("ad63weary", emoteTable.get("d63weary"));
+		
+		servers.put(guild.getId(), emoteTable);
 	}
 	
 	/**
 	 * This function will return the proper string to use for the result of the given success die roll.
 	 * @param success The result on the success die
 	 * @param isWeary Whether or not the character is weary
+	 * @param isAdversary Whether an adversary is rolling
+	 * @param guild The guild to retrieve the string from
 	 * @return String to insert into the roll results
 	 */
-	public String getSuccessString(int success, boolean isWeary) {
-		switch(success) {
-		case 1:
-			if (isWeary)
-			{
-				return this.d61weary;
-			}
-			else
-			{
-				return this.d61;
-			}
-		case 2:
-			if (isWeary)
-			{
-				return this.d62weary;
-			}
-			else
-			{
-				return this.d62;
-			}
-		case 3:
-			if (isWeary)
-			{
-				return this.d63weary;
-			}
-			else
-			{
-				return this.d63;
-			}
-		case 4:
-			return this.d64;
-		case 5:
-			return this.d65;
-		case 6:
-			return this.d66;
-		default:
-				LOGGER.error("Unable to find face for success result of {}", success);
-				return "-1";
+	public String getSuccessString(int success, boolean isWeary, boolean isAdversary, Guild guild) {
+		getEmoteStrings(guild, false);
+		String key = "";
+		
+		if (isAdversary)
+		{
+			key = key.concat("a");
 		}
+		
+		key = key.concat("d6");
+		
+		key = key.concat(String.valueOf(success));
+		
+		if (success <= 3 && isWeary)
+		{
+			key = key.concat("weary");
+		}
+		
+		LOGGER.debug("Getting emote string for success die result of {}. Key is {}", success, key);
+		return servers.get(guild.getId()).get(key);
 	}
 	
 	/**
@@ -172,49 +127,43 @@ public class EmoteStrings implements EmoteInterface{
 	 * the roll was performed by an adversary.
 	 * @param feat The result of the feat die. 0 for the relevant face
 	 * @param isAdversary Whether the roll was performed by an adversary. Necessary to interpret the result of 0
+	 * @param guild The guild requesting the string
 	 * @return String to insert into roll results.
 	 */
-	public String getFeatString(int feat, boolean isAdversary) {
-		if (isAdversary && feat == 0)
+	public String getFeatString(int feat, boolean isAdversary, Guild guild) {
+		getEmoteStrings(guild, false);
+		String key = "";
+		
+		if (isAdversary)
 		{
-			return this.d1212;
+			key = key.concat("a");
 		}
-		else if (!isAdversary && feat == 0)
+		
+		key = key.concat("d12");
+		
+		if (feat != 0)
 		{
-			return this.d1211;
+			key = key.concat(String.valueOf(feat));
 		}
 		else
 		{
-			switch (feat) {
-			case 1:
-				return this.d121;
-			case 2: 
-				return this.d122;
-			case 3: 
-				return this.d123;
-			case 4: 
-				return this.d124;
-			case 5: 
-				return this.d125;
-			case 6: 
-				return this.d126;
-			case 7:
-				return this.d127;
-			case 8: 
-				return this.d128;
-			case 9: 
-				return this.d129;
-			case 10: 
-				return this.d1210;
-			case 11:
-				return this.d1211;
-			case 12:
-				return this.d1212;
-			default:
-				LOGGER.error("Unable to find face for feat result of {}", feat);
-				return "-1";
-					
+			if (isAdversary)
+			{
+				key = key.concat(String.valueOf(12));
+			}
+			else
+			{
+				key = key.concat(String.valueOf(11));
 			}
 		}
+		
+		LOGGER.debug("Getting emote string for feat die result of {}. Key is {}", feat, key);
+		
+		return servers.get(guild.getId()).get(key);
+	}
+	
+	public void reloadEmotes(Guild guild)
+	{
+		getEmoteStrings(guild, true);
 	}
 }

--- a/src/torRpgBot/FreeDice.java
+++ b/src/torRpgBot/FreeDice.java
@@ -43,7 +43,6 @@ public class FreeDice extends Command {
 	protected void handleCommand(MessageReceivedEvent event) {
 		int numd12 = getNumD12(event.getMessage().getContentDisplay());
 		int numd6 = getNumD6(event.getMessage().getContentDisplay());
-		emotes.getEmoteStrings(event.getGuild());
 		
 		LOGGER.info("Received free dice command: {}.", event.getMessage().getContentDisplay());
 		LOGGER.debug("Num of d12: {}, num of d6: {}", numd12, numd6);
@@ -58,11 +57,11 @@ public class FreeDice extends Command {
 			{
 				if (num == 0)
 				{
-					result = result.concat(emotes.getFeatString(diceRoller.rolld12(), false));
+					result = result.concat(emotes.getFeatString(diceRoller.rolld12(), false, event.getGuild()));
 				}
 				else
 				{
-					result = result.concat(", " + emotes.getFeatString(diceRoller.rolld12(), false));
+					result = result.concat(", " + emotes.getFeatString(diceRoller.rolld12(), false, event.getGuild()));
 				}
 			}
 		}
@@ -75,11 +74,11 @@ public class FreeDice extends Command {
 			{
 				if (num == 0)
 				{
-					result = result.concat(emotes.getSuccessString(diceRoller.rolld6(), false));
+					result = result.concat(emotes.getSuccessString(diceRoller.rolld6(), false, false, event.getGuild()));
 				}
 				else
 				{
-					result = result.concat(", " + emotes.getSuccessString(diceRoller.rolld6(), false));
+					result = result.concat(", " + emotes.getSuccessString(diceRoller.rolld6(), false, false, event.getGuild()));
 				}
 			}
 		}

--- a/src/torRpgBot/ReloadCommand.java
+++ b/src/torRpgBot/ReloadCommand.java
@@ -1,0 +1,43 @@
+package torRpgBot;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.dv8tion.jda.core.entities.Guild;
+import net.dv8tion.jda.core.events.message.MessageReceivedEvent;
+
+public class ReloadCommand extends Command{
+	
+	private EmoteInterface emoteProvider;
+
+	public ReloadCommand(List<CommandFlag> flags, EmoteInterface emoteProvider) {
+		super(flags);
+		this.emoteProvider = emoteProvider;
+	}
+
+	@Override
+	protected void handleCommand(MessageReceivedEvent event) {
+		Guild guild = event.getGuild();
+		
+		emoteProvider.reloadEmotes(guild);
+		
+	}
+
+	@Override
+	protected String getHelp() {
+		return "__**Reload Emotes**__\n" +
+				"**Aliases:** reloadEmotes\n" +
+				"**Syntax:** command\n" +
+				"**Description:** This command will reload the emotes from the current server. Only use if the emotes have changed"
+				+ "since the last time the bot was re-started.";
+	}
+
+	@Override
+	protected List<String> getAliases() {
+		List<String> aliases = new ArrayList<String>();
+		aliases.add("reloadEmotes");
+		aliases.add("reloademotes");
+		return aliases;
+	}
+
+}

--- a/src/torRpgBot/TorDice.java
+++ b/src/torRpgBot/TorDice.java
@@ -114,11 +114,8 @@ public abstract class TorDice extends Command{
 			LOGGER.debug("No success dice to roll, setting the results to an empty array");
 			successDice = new int[0];
 		}
-		
-		// We must call this function before compileResults, since compileResults doesn't get a copy of the Guild
-		// but we need to load the strings before compileResults calls for them.
-		emoteProvider.getEmoteStrings(guild);
-		return compileResult(feat, successDice, isAdversary, parsedCommand, author);
+
+		return compileResult(feat, successDice, isAdversary, parsedCommand, author, guild);
 	}
 	
 	
@@ -475,7 +472,7 @@ public abstract class TorDice extends Command{
 	 * @return String to be sent to Discord describing the roll and the result.
 	 */
 	/* private -> testing*/ String compileResult(int[] feat, int[] success, boolean isAdversary,
-			CommandResults command, String author) {
+			CommandResults command, String author, Guild guild) {
 		String result = author;
 		// Final String: NAME [wearily] rolled SKILL and got: FEAT; SUCCESS1, SUCCESS2, ... = SUM >|< TN A [Great|Extraordinary] Success!\n Unused dice: unusedFeat, mastery
 		int sum = 0;
@@ -503,28 +500,30 @@ public abstract class TorDice extends Command{
 			finalFeatResult = sum = feat[0];
 		}
 		
-		featString = emoteProvider.getFeatString(finalFeatResult, isAdversary);
+		featString = emoteProvider.getFeatString(finalFeatResult, isAdversary, guild);
 		boolean isGreatSuccess = false;
 		boolean isExtraordinarySuccess = false;
 		
 		if (command.hasAdvantage)
 		{
-			unusedFeat = emoteProvider.getFeatString(Math.min(feat[0], feat[1]), isAdversary);
+			unusedFeat = emoteProvider.getFeatString(Math.min(feat[0], feat[1]), isAdversary, guild);
 		}
 		else if (command.hasDisadvantage)
 		{
-			unusedFeat = emoteProvider.getFeatString(Math.max(feat[0], feat[1]), isAdversary);
+			unusedFeat = emoteProvider.getFeatString(Math.max(feat[0], feat[1]), isAdversary, guild);
 		}
 		
 		for (int i = 0; i < success.length; i++)
 		{
 			if (i >= command.numOfSuccess)
 			{
-				mastery = mastery.concat(", " + emoteProvider.getSuccessString(success[i], command.isWeary));
+				mastery = mastery.concat(", " +
+						emoteProvider.getSuccessString(success[i], command.isWeary, isAdversary, guild));
 			}
 			else
 			{
-				successString = successString.concat(", " + emoteProvider.getSuccessString(success[i], command.isWeary));
+				successString = successString.concat(", " +
+						emoteProvider.getSuccessString(success[i], command.isWeary, isAdversary, guild));
 			}
 			
 			if (i >= command.numOfSuccess)

--- a/src/torRpgBot/torRpgBot.java
+++ b/src/torRpgBot/torRpgBot.java
@@ -25,9 +25,10 @@ public class torRpgBot {
 		
 		DiceProvider dice = new DiceProvider();
 		SettingsManager settingsManager = new SettingsManager("torRpgBotSettings.json");
-		EmoteInterface emoteRollProvider = new EmoteStrings();
-		EmoteInterface emoteAdversaryProvider = new EmoteStrings();
-		EmoteInterface emoteFreeProvider = new EmoteStrings();
+		EmoteStrings emoteProvider = new EmoteStrings();
+		EmoteInterface emoteRollProvider = emoteProvider;
+		EmoteInterface emoteAdversaryProvider = emoteProvider;
+		EmoteInterface emoteFreeProvider = emoteProvider;
 		
 		settingsManager.loadSettings();
 		
@@ -45,7 +46,8 @@ public class torRpgBot {
         	jdaBuilder.addEventListener(helpCommand.registerCommand(new AdversaryCommand(settingsManager.getSettings().commandFlags, dice, emoteAdversaryProvider)));
         	jdaBuilder.addEventListener(helpCommand.registerCommand(new SetFlag(settingsManager.getSettings().commandFlags, settingsManager)));
         	jdaBuilder.addEventListener(helpCommand.registerCommand(new FreeDice(settingsManager.getSettings().commandFlags, emoteFreeProvider, dice)));
-            
+        	jdaBuilder.addEventListener(helpCommand.registerCommand(new ReloadCommand(settingsManager.getSettings().commandFlags, emoteProvider)));
+        	
             @SuppressWarnings("unused")
 			JDA jda = jdaBuilder.buildBlocking();
             


### PR DESCRIPTION
Added the ability to have adversary dice provide a different emote. These emotes are keyed as "aX", where "X" is the regular die emote name (such as "d121", d63weary", etc.). If no adversary die emote exists for a given die result, then the regular emote is used.

Additionally, changed the background implementation of the emote interface to use a hashtable. This hashtable is shared across all instances of the EmtoeStrings class; saving memory and only needing to be updated once per server. 

The hashtable is keyed on the String ID of the server, and provides another hashtable. This hashtable is keyed on the emote name (such as "d121", and provides the full emote string for the emote on the server of the containing entry. For a given server, it's hashtable entry is only updated on the first roll on that server after the bot is started, unless the new command "reloadEmotes" is issued, which will force a reload of the hashtable. This is to support changing the emojis for the dice without having to restart the bot.